### PR TITLE
Major memory leak in Component and Request

### DIFF
--- a/lib/Mason/Component.pm
+++ b/lib/Mason/Component.pm
@@ -3,6 +3,7 @@ use Moose;    # no Mason::Moose - don't want StrictConstructor
 use MooseX::HasDefaults::RO;
 use Method::Signatures::Simple;
 use Log::Any;
+use Scalar::Util qw(weaken);
 
 with 'Mason::Filters::Standard';
 
@@ -13,6 +14,8 @@ has 'm'    => ( required => 1, weak_ref => 1 );
 
 method BUILD ($params) {
     $self->{_orig_params} = $params;
+    weaken $self->{_orig_params}->{m};
+    return $self->{_orig_params};
 }
 
 method cmeta () {

--- a/lib/Mason/Request.pm
+++ b/lib/Mason/Request.pm
@@ -7,7 +7,7 @@ use Mason::Exceptions;
 use Mason::TieHandle;
 use Mason::Types;
 use Mason::Moose;
-use Scalar::Util qw(blessed reftype);
+use Scalar::Util qw(blessed reftype weaken);
 use Try::Tiny;
 
 my $default_out = sub { my ( $text, $self ) = @_; $self->result->_append_output($text) };
@@ -45,6 +45,8 @@ method current_request () { $current_request }
 
 method BUILD ($params) {
     $self->{orig_request_params} = $params;
+    weaken $self->{orig_request_params}->{interp};
+    return $self->{orig_request_params};
 }
 
 method _build_result () {


### PR DESCRIPTION
I traced down a massive memory leak in my Catalyst app today in part to Mason.  The issue is caused by _orig_params in ::Component and _orig_request_params in ::Request.  While the Moose attributes are appropriately marked as weak_ref, the copies made in BUILD are not and result in a memory cycle.

```
Cycle #1
    MC0::index_mc H->{_orig_params} => %I
    %I->{m} => Moose::Meta::Class::__ANON__::SERIAL::52 J
    Moose::Meta::Class::__ANON__::SERIAL::52 J->{orig_request_params} => %K
    %K->{interp} => Moose::Meta::Class::__ANON__::SERIAL::51 E
    Moose::Meta::Class::__ANON__::SERIAL::51 E->{match_request_path} => &F
    closure &F, $interp => $G
    $G => Moose::Meta::Class::__ANON__::SERIAL::51 E
Cycle #2
    MC0::index_mc H->{_orig_params} => %I
    %I->{m} => Moose::Meta::Class::__ANON__::SERIAL::52 J
    Moose::Meta::Class::__ANON__::SERIAL::52 J->{page} => MC0::index_mc H
```

In the case of running under Catalyst (with Catalyst::View::Mason2), it causes the component itself and the entire stash to leak on each request (as the stash contents are passed in as parameters).

This is a (very naive) patch to weaken the copies of the weak_ref parameters in BUILD.  This fixed the issue for me.
