### PR TITLE
Make also immutable anonymous final subclasses.

### DIFF
--- a/lib/Mason/PluginManager.pm
+++ b/lib/Mason/PluginManager.pm
@@ -79,6 +79,8 @@ method apply_plugins_to_class ($class: $base_subclass, $name, $plugins) {
         $base_subclass, $name, $plugins, \@roles, $final_subclass )
       if $log->is_debug;
 
+    $final_subclass->meta->make_immutable if $final_subclass->can('meta');
+
     $apply_plugins_cache{$key} = $final_subclass;
     return $final_subclass;
 }


### PR DESCRIPTION
Hi.

I benchmarked just simple case.
Please consider it.

Cheers
Tomohiro Hosaka

```
% git branch
* master
  people/bokutin/filter_parser_bug
  people/bokutin/make_immutable
% perl -I lib benchmark.pl
timethis 10000: 11 wallclock secs (10.01 usr +  0.11 sys = 10.12 CPU) @ 988.14/s (n=10000)
% git checkout people/bokutin/make_immutable
Switched to branch 'people/bokutin/make_immutable'
% perl -I lib benchmark.pl                  
timethis 10000:  5 wallclock secs ( 4.40 usr +  0.10 sys =  4.50 CPU) @ 2222.22/s (n=10000)
% git diff master
diff --git a/lib/Mason/PluginManager.pm b/lib/Mason/PluginManager.pm
index d1caccf..65c26dd 100644
--- a/lib/Mason/PluginManager.pm
+++ b/lib/Mason/PluginManager.pm
@@ -79,6 +79,8 @@ method apply_plugins_to_class ($class: $base_subclass, $name, $plugins) {
         $base_subclass, $name, $plugins, \@roles, $final_subclass )
       if $log->is_debug;

+    $final_subclass->meta->make_immutable if $final_subclass->can('meta');
+
     $apply_plugins_cache{$key} = $final_subclass;
     return $final_subclass;
 }
% cat benchmark.pl 
use Modern::Perl;
use Benchmark qw(:all);

use Mason;

my $m2 = Mason->new(
    autobase_names => [],
    autoextend_request_path => 0,
    comp_root => "comps-m2",
    data_dir => 'var/m2_cache',
    dhandler_names => [],
    index_names => [],
    static_source => 0,
    top_level_extensions => [],
);

$m2->run('/html.mc')->output;

timethis (10000, sub {
    $m2->run('/html.mc')->output;
});
% prove -I lib t
-- snip --
All tests successful.
Files=21, Tests=277, 36 wallclock secs ( 0.17 usr  0.09 sys + 22.47 cusr  1.57 csys = 24.30 CPU)
Result: PASS
% 
```
