### PR TITLE
Added the "class_header" attribute to the "new" constructor

### DIFF
--- a/lib/Mason/Compilation.pm
+++ b/lib/Mason/Compilation.pm
@@ -94,7 +94,7 @@ method output_class_footer () {
 }
 
 method output_class_header () {
-    return "";
+    return $self->interp->class_header;
 }
 
 method parse () {
@@ -917,7 +917,8 @@ Perl code to be added at the bottom of the class. Empty by default.
 =item output_class_header ()
 
 Perl code to be added at the top of the class, just after initialization of
-Moose, C<$m> and other required pieces. Empty by default.
+Moose, C<$m> and other required pieces. The default is the value of Mason::Interp::class_header
+or an empty string.
 
     # Add to the top of every component class:
     #   use Foo;

--- a/lib/Mason/Interp.pm
+++ b/lib/Mason/Interp.pm
@@ -37,6 +37,8 @@ has 'pure_perl_extensions'     => ( default => sub { ['.mp'] } );
 has 'static_source'            => ();
 has 'static_source_touch_file' => ();
 has 'top_level_extensions'     => ( default => sub { ['.mc', '.mp'] } );
+has 'class_header'             => ( default => '' );
+
 
 # Derived attributes
 #
@@ -946,6 +948,18 @@ A listref of file extensions of components to be considered "top level",
 accessible directly from C<< $interp->run >> or a web request. Default is C<<
 ['.mp', '.mc'] >>. If an empty list is specified, then there will be I<no>
 restriction; that is, I<all> components will be considered top level.
+
+=item class_header
+
+The default content of Mason::Compilation::output_class_header method. For more advanced features you can overwrite it.
+
+    my $mason = Mason->new(
+            comp_root => '.',
+            class_header => qq(
+                use Foo::Bar;
+                use Baz;
+            ),
+        );
 
 =back
 


### PR DESCRIPTION
Hi,

now it is easy to adding class_headers into every mobj files without the need of overwriting Mason::Compilation.pm, so now is possible to write:

my $mason = Mason->new(
    comp_root => '.',
    data_dir => '/tmp/xxx',
    class_header => qq(
         use Foo;
         use Bar;
    ),
);

Of course, for some more advanced features the user still can overwrite the "output_class_header" method.
