### PR TITLE
pod fix for allow_path_info.

### DIFF
--- a/lib/Mason/Component.pm
+++ b/lib/Mason/Component.pm
@@ -194,7 +194,7 @@ determine whether the path_info is allowed. Default is false. See
 L<Mason::Manual::RequestDispatch/Partial Paths|Mason::Manual::RequestDispatch>.
 
     <%class>
-    CLASS->allow_path_info(1);
+    method allow_path_info { 1 }
     </%class>
 
 =back


### PR DESCRIPTION
Hi, Jonathan.

I found a wrong line in POD.

allow_path_info is method. not attribute.
So, CLASS->allow_path_info(1) is invalid.

Cheers
Tomohiro Hosaka
