### PR TITLE
$interp->set_global should allow undef and false values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ profile
 release
 tmp
 z-backup
+/.build/

--- a/lib/Mason/Interp.pm
+++ b/lib/Mason/Interp.pm
@@ -364,8 +364,9 @@ method run () {
 }
 
 method set_global () {
+    croak "set_global expects a var name and value" unless @_ > 1;
+    croak "set_global only supports scalars not lists at this time" if @_ > 2;
     my ( $spec, $value ) = @_;
-    croak "set_global expects a var name and value" unless $value;
     my ( $sigil, $name ) = $self->_parse_global_spec($spec);
     croak "${sigil}${name} is not in the allowed globals list"
       unless $self->allowed_globals_hash->{"${sigil}${name}"};

--- a/lib/Mason/t/Globals.pm
+++ b/lib/Mason/t/Globals.pm
@@ -3,11 +3,28 @@ use Test::Class::Most parent => 'Mason::Test::Class';
 
 sub test_globals : Tests {
     my $self = shift;
-    $self->setup_interp( allow_globals => [qw(scalar $scalar2)] );
+
+    throws_ok {
+        $self->setup_interp( allow_globals => [qw( @array )] );
+    } qr/only scalar globals supported/;
+
+    throws_ok {
+        $self->setup_interp( allow_globals => [qw( %hash )] );
+    } qr/only scalar globals supported/;
+
+    $self->setup_interp( allow_globals => [qw(scalar $scalar2 $scalar3 )] );
     my $interp = $self->interp;
+
+    throws_ok { $interp->set_global( '$bad', 8 ) } qr/\$bad is not in the allowed globals list/;
+    throws_ok { $interp->set_global( 'scalar' ) } qr/set_global expects a var name and value/;
+    throws_ok { $interp->set_global( 'scalar', 1, 2 ) } qr/set_global only supports scalars/;
+
+    lives_ok  { $interp->set_global( '$scalar3', 'This value should vanish' ) };
+    lives_ok  { $interp->set_global( '$scalar3', undef ) };
+
     $interp->set_global( 'scalar',   5 );
     $interp->set_global( '$scalar2', 'vanilla' );
-    throws_ok { $interp->set_global( '$bad', 8 ) } qr/\$bad is not in the allowed globals list/;
+
     $self->add_comp(
         path => '/values',
         src  => '
@@ -21,6 +38,7 @@ $scalar2 = <% $scalar2 %>
 % $scalar++;
 % $scalar2 .= "s";
 <& /values &>
+% die q($scalar3 should not be defined) if defined $scalar3;
 ',
         expect => '
 scalar = 5


### PR DESCRIPTION
Currently there is no way to unset a global value again (or set a global to any false value if I read the sources correctly). Because of that, global values run the risk of bleeding into the the next rendering when running a persistent interpreter object.

(Sorry for also changing .gitignore, I am still trying to find my way around pull requests and contributing to projects)
