### PR TITLE
pod fix

### DIFF
--- a/lib/Mason/Plugin/LvalueAttributes.pm
+++ b/lib/Mason/Plugin/LvalueAttributes.pm
@@ -53,5 +53,5 @@ convenience of the Lvalue attributes outweighs the need for setter features.
 =head1 ACKNOWLEDGEMENTS
 
 Inspired by Christopher Brown's
-L<MooseX::Meta::Attribute::Lvalue|MooseX::Meta::Attribute::Lvalue >.
+L<MooseX::Meta::Attribute::Lvalue|MooseX::Meta::Attribute::Lvalue>.
 


### PR DESCRIPTION
Currently at the bottom of this page:
https://metacpan.org/module/Mason::Plugin::LvalueAttributes

This error appears:
Around line 58:
L<> starts or ends with whitespace

And this change should resolve it.
