### PR TITLE
Replaced Class::MOP::load_class and is_class_loaded with Class::Load::load_class

### DIFF
--- a/lib/Mason/Interp.pm
+++ b/lib/Mason/Interp.pm
@@ -11,6 +11,7 @@ use Mason::Result;
 use Mason::Types;
 use Mason::Util
   qw(can_load catdir catfile combine_similar_paths find_wanted first_index is_absolute json_decode mason_canon_path read_file taint_is_on touch_file uniq write_file);
+use Class::Load;
 use Memoize;
 use Moose::Util::TypeConstraints;
 use Mason::Moose;
@@ -743,7 +744,7 @@ sub _define_class_override_methods {
             "_build_$method_name" => sub {
                 my $self       = shift;
                 my $base_class = $self->$base_method_name;
-                Class::MOP::load_class($base_class);
+                Class::Load::load_class($base_class);
                 return Mason::PluginManager->apply_plugins_to_class( $base_class, $name,
                     $self->plugins );
             }

--- a/lib/Mason/Plugin.pm
+++ b/lib/Mason/Plugin.pm
@@ -1,6 +1,7 @@
 package Mason::Plugin;
 use Mason::PluginRole;
 use Mason::Util qw(can_load);
+use Class::Load;
 
 method requires_plugins ($plugin_class:) {
     return ();
@@ -16,7 +17,7 @@ method get_roles_for_mason_class ($plugin_class: $name) {
     if ( $name eq 'Component' ) {
         push( @roles_to_try, join( "::", $plugin_class, 'Filters' ) );
     }
-    my @roles = grep { Class::MOP::is_class_loaded($_) || can_load($_) } @roles_to_try;
+    my @roles = grep { Class::Load::is_class_loaded($_) || can_load($_) } @roles_to_try;
     return @roles;
 }
 

--- a/lib/Mason/Test/Class.pm
+++ b/lib/Mason/Test/Class.pm
@@ -8,6 +8,7 @@ use Mason::Util qw(trim write_file);
 use Method::Signatures::Simple;
 use Test::Class::Most;
 use Test::LongString;
+use Class::Load;
 use strict;
 use warnings;
 
@@ -54,7 +55,7 @@ method create_interp () {
     my (%params) = @_;
     $params{plugins} = $default_plugins if @$default_plugins;
     my $mason_root_class = delete( $params{mason_root_class} ) || 'Mason';
-    Class::MOP::load_class($mason_root_class);
+    Class::Load::load_class($mason_root_class);
     rmtree( $self->data_dir );
     return $mason_root_class->new(
         comp_root => $self->comp_root,

--- a/lib/Mason/Util.pm
+++ b/lib/Mason/Util.pm
@@ -1,7 +1,7 @@
 package Mason::Util;
 use Carp;
-use Class::MOP;
 use Class::Unload;
+use Class::Load;
 use Data::Dumper;
 use Fcntl qw( :DEFAULT :seek );
 use File::Find;
@@ -33,7 +33,7 @@ sub can_load {
 
     my $result;
     try {
-        Class::MOP::load_class($class_name);
+        Class::Load::load_class($class_name);
         $result = 1;
     }
     catch {


### PR DESCRIPTION
Hi Jon,

Just a few small changes since the Moose causes big stacktraces since the deprecation.

Lianna
