### PR TITLE
fix another POD error

### DIFF
--- a/lib/Mason/Component.pm
+++ b/lib/Mason/Component.pm
@@ -191,7 +191,7 @@ parent.
 
 This method is called when the request path has a path_info portion, to
 determine whether the path_info is allowed. Default is false. See
-L<Mason::Manual::RequestDispatch/Partial Paths|Mason::Manual::RequestDispatch>.
+L<Mason::Manual::RequestDispatch|Mason::Manual::RequestDispatch/Partial Paths>.
 
     <%class>
     method allow_path_info { 1 }


### PR DESCRIPTION
(in addition to the one reported by d. steinbrunner)

the POD error is: "alternative text 'Mason::Manual::RequestDispatch/Partial Paths' contains non-escaped | or /"
