### PR TITLE
Add missing strictures

### DIFF
--- a/t/Autobase.t
+++ b/t/Autobase.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Autobase;
 Mason::t::Autobase->runtests;

--- a/t/CompCalls.t
+++ b/t/CompCalls.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::CompCalls;
 Mason::t::CompCalls->runtests;

--- a/t/Compilation.t
+++ b/t/Compilation.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Compilation;
 Mason::t::Compilation->runtests;

--- a/t/ComponentMeta.t
+++ b/t/ComponentMeta.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::ComponentMeta;
 Mason::t::ComponentMeta->runtests;

--- a/t/Defer.t
+++ b/t/Defer.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Defer;
 Mason::t::Defer->runtests;

--- a/t/DollarDot.t
+++ b/t/DollarDot.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::DollarDot;
 Mason::t::DollarDot->runtests;

--- a/t/Errors.t
+++ b/t/Errors.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Errors;
 Mason::t::Errors->runtests();

--- a/t/Filters.t
+++ b/t/Filters.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Filters;
 Mason::t::Filters->runtests;

--- a/t/Globals.t
+++ b/t/Globals.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Globals;
 Mason::t::Globals->runtests;

--- a/t/Interp.t
+++ b/t/Interp.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Interp;
 Mason::t::Interp->runtests();

--- a/t/LvalueAttributes.t
+++ b/t/LvalueAttributes.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::LvalueAttributes;
 Mason::t::LvalueAttributes->runtests;

--- a/t/Plugins.t
+++ b/t/Plugins.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Plugins;
 Mason::t::Plugins->runtests;

--- a/t/Reload.t
+++ b/t/Reload.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Reload;
 Mason::t::Reload->runtests();

--- a/t/Request.t
+++ b/t/Request.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Request;
 Mason::t::Request->runtests;

--- a/t/ResolveURI.t
+++ b/t/ResolveURI.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::ResolveURI;
 Mason::t::ResolveURI->runtests;

--- a/t/Sanity.t
+++ b/t/Sanity.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Sanity;
 Mason::t::Sanity->runtests;

--- a/t/Sections.t
+++ b/t/Sections.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Sections;
 Mason::t::Sections->runtests();

--- a/t/StaticSource.t
+++ b/t/StaticSource.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::StaticSource;
 Mason::t::StaticSource->runtests;

--- a/t/Syntax.t
+++ b/t/Syntax.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Syntax;
 Mason::t::Syntax->runtests();

--- a/t/Util.t
+++ b/t/Util.t
@@ -1,3 +1,7 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Mason::t::Util;
 Mason::t::Util->runtests;

--- a/xt/author/leaks.t
+++ b/xt/author/leaks.t
@@ -1,4 +1,8 @@
-#!perl -w
+#!perl
+
+use strict;
+use warnings;
+
 use Devel::LeakGuard::Object qw(leakguard);
 use File::Path qw(mkpath);
 use File::Temp qw(tempdir);


### PR DESCRIPTION
These changes add the warnings and strict pragmas to all normal test files and one of the author tests.  Although the tests use their own test runner and were already using the `-w` option to `perl` to switch on warnings, using the pragmas is better aligned to current best practice and possibly also more platform independent.  If it is wished that this PR needs to be updated in anyway to be better aligned with project standards, please let me know and I'll make the relevant changes and resubmit.