### PR TITLE
Minor cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build
 .tidyall.d
 Mason-*
 NOTES

--- a/lib/Mason.pm
+++ b/lib/Mason.pm
@@ -56,7 +56,7 @@ Mason - Powerful, high-performance templating for the web and beyond
     % my $name = "Mason";
     Hello world! Welcome to <% $name %>.
 
-  #!/usr/local/bin/perl
+  #!/usr/bin/env perl
   use Mason;
   my $mason = Mason->new(comp_root => '...');
   print $mason->run('/foo')->output;


### PR DESCRIPTION
This PR merely makes two minor cleanups to the distribution.  It ignores the `.build` directory created by DistZilla so that this directory isn't shown in `git status` output; and it makes the example code in `lib/Mason.pm` use a more general shebang line which would allow users to use the `perl` in their path and not specifically that under `/usr/local/bin` (which probably doesn't exist on many systems these days).