### PR TITLE
Add missing dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,6 +38,7 @@ file = lib/Mason/Util.pm
 [PodWeaverIfPod]
 [PruneCruft]
 
+; authordep Moose::Autobox
 [Prereqs / RuntimeRequires]
 Capture::Tiny = 0
 Class::Load = 0

--- a/dist.ini
+++ b/dist.ini
@@ -60,6 +60,7 @@ Scalar::Util = 1.01
 Try::Tiny = 0
 
 [Prereqs / TestRequires]
+Devel::LeakGuard::Object = 0.08
 Test::Class::Most = 0
 Test::LongString = 0
 


### PR DESCRIPTION
The modules `Moose::Autobox` and `Devel::LeakGuard::Object` need to be installed before `Mason` can be tested.  These commits add these dependencies and their commit messages describe the rationale behind why these changes are necessary.