### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --no-skip-satisfied ExtUtils::MakeMaker
+    - dzil authordeps --missing | cpanm  --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil -Ilib listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil -Ilib test --author --release


### PR DESCRIPTION
Travis-CI (https://travis-ci.org) is a very good continuous integration service.  This PR adds the Travis-CI configuration file with a working build and test configuration.  As soon as `Devel::LeakGuard::Object` version 0.08 is available from CPAN, the explicit installation of `ExtUtils::MakeMaker` can be removed.

This PR is intended to be helpful; if it should be modified or updated before it can be accepted, please let me know.  If it is undesirable to add this functionality to the project, please simply say so and close the PR.