### PR TITLE
Fixed bug with classname generation

### DIFF
--- a/lib/Mason/Interp.pm
+++ b/lib/Mason/Interp.pm
@@ -593,7 +593,7 @@ method _collect_paths_for_all_comp_roots ($code) {
 
 method _comp_class_for_path ($path) {
     my $classname = substr( $path, 1 );
-    $classname =~ s/[^\w]/_/g;
+    $classname =~ s/[^\w\/]/_/g;
     $classname =~ s/\//::/g;
     $classname = join( "::", $self->component_class_prefix, $classname );
     return $classname;


### PR DESCRIPTION
Seems it was intended to convert foo/bar.mc to MC0::foo::bar_mc but current implementation makes MC0::foo_bar_mc
